### PR TITLE
Fix compilation (XmdvTool.pro)

### DIFF
--- a/XmdvTool.pro
+++ b/XmdvTool.pro
@@ -1,3 +1,5 @@
+LIBS += -lGLU
+QMAKE_CXXFLAGS += -fpermissive
 TEMPLATE = app
 TARGET = XmdvTool
 QT += core \


### PR DESCRIPTION
This adds missing library `-lGLU` and `-fpermissive` flag to build under newer releases of GCC.

Fixes https://github.com/kaiyuzhao/XmdvTool/issues/6